### PR TITLE
Add bookmark API with database model

### DIFF
--- a/src/app/api/bookmark/controllers/createBookmark.ts
+++ b/src/app/api/bookmark/controllers/createBookmark.ts
@@ -1,0 +1,43 @@
+import { NextRequest } from 'next/server';
+import Bookmark from '@/database/models/Bookmark';
+import Challenge from '@/database/models/Challenge';
+import { withAuth } from '@/lib/middleware/withAuth';
+import { withLogging } from '@/lib/middleware/withLogging';
+import resUtil from '@/lib/utils/responseUtil';
+import getUserFromRequest from '@/lib/utils/getUserFromRequest';
+import { validateRequiredFields } from '@/lib/utils/validateRequiredFields';
+
+async function postHandler(req: NextRequest) {
+  try {
+    const body = await req.json();
+    const validation = validateRequiredFields(body, ['challengeId']);
+    if (validation) return validation;
+
+    const { challengeId } = body;
+    const user = await getUserFromRequest();
+
+    const challenge = await Challenge.findByPk(challengeId);
+    if (!challenge) {
+      return resUtil.successFalse({
+        status: 404,
+        message: '챌린지를 찾을 수 없습니다.',
+        data: {},
+      });
+    }
+
+    const [bookmark] = await Bookmark.findOrCreate({
+      where: { userId: user?.id, challengeId },
+    });
+
+    return resUtil.successTrue({
+      status: 201,
+      message: '북마크 생성 성공',
+      data: bookmark,
+    });
+  } catch (error) {
+    console.error(error);
+    return resUtil.unknownError({});
+  }
+}
+
+export const CreateBookmark = withLogging(withAuth(postHandler));

--- a/src/app/api/bookmark/controllers/deleteBookmark.ts
+++ b/src/app/api/bookmark/controllers/deleteBookmark.ts
@@ -1,0 +1,35 @@
+import { NextRequest } from 'next/server';
+import Bookmark from '@/database/models/Bookmark';
+import { withAuth } from '@/lib/middleware/withAuth';
+import { withLogging } from '@/lib/middleware/withLogging';
+import resUtil from '@/lib/utils/responseUtil';
+import getUserFromRequest from '@/lib/utils/getUserFromRequest';
+
+async function deleteHandler(req: NextRequest) {
+  try {
+    const challengeId = req.nextUrl.searchParams.get('challengeId');
+    if (!challengeId) {
+      return resUtil.successFalse({
+        status: 400,
+        message: 'challengeId 값이 필요합니다.',
+        data: {},
+      });
+    }
+
+    const user = await getUserFromRequest();
+    await Bookmark.destroy({
+      where: { userId: user?.id, challengeId: Number(challengeId) },
+    });
+
+    return resUtil.successTrue({
+      status: 200,
+      message: '북마크 삭제 성공',
+      data: {},
+    });
+  } catch (error) {
+    console.error(error);
+    return resUtil.unknownError({});
+  }
+}
+
+export const DeleteBookmark = withLogging(withAuth(deleteHandler));

--- a/src/app/api/bookmark/controllers/getBookmark.ts
+++ b/src/app/api/bookmark/controllers/getBookmark.ts
@@ -1,0 +1,28 @@
+import { NextRequest } from 'next/server';
+import Bookmark from '@/database/models/Bookmark';
+import Challenge from '@/database/models/Challenge';
+import { withAuth } from '@/lib/middleware/withAuth';
+import { withLogging } from '@/lib/middleware/withLogging';
+import resUtil from '@/lib/utils/responseUtil';
+import getUserFromRequest from '@/lib/utils/getUserFromRequest';
+
+async function getHandler(req: NextRequest) {
+  try {
+    const user = await getUserFromRequest();
+    const bookmarks = await Bookmark.findAll({
+      where: { userId: user?.id },
+      include: [Challenge],
+    });
+
+    return resUtil.successTrue({
+      status: 200,
+      message: '북마크 조회 성공',
+      data: bookmarks,
+    });
+  } catch (error) {
+    console.error(error);
+    return resUtil.unknownError({});
+  }
+}
+
+export const GetBookmark = withLogging(withAuth(getHandler));

--- a/src/app/api/bookmark/route.ts
+++ b/src/app/api/bookmark/route.ts
@@ -1,0 +1,8 @@
+import { CreateBookmark } from './controllers/createBookmark';
+export const POST = CreateBookmark;
+
+import { GetBookmark } from './controllers/getBookmark';
+export const GET = GetBookmark;
+
+import { DeleteBookmark } from './controllers/deleteBookmark';
+export const DELETE = DeleteBookmark;

--- a/src/database/associations.ts
+++ b/src/database/associations.ts
@@ -3,6 +3,7 @@ import Point from './models/Point';
 import Transactions from './models/Transactions';
 import Challenge from './models/Challenge';
 import ChallengeParticipants from './models/ChallengeParticipants';
+import Bookmark from './models/Bookmark';
 import './models/File';
 
 Users.hasOne(Point, { foreignKey: 'userId' });
@@ -20,5 +21,16 @@ Users.belongsToMany(Challenge, {
 });
 Challenge.belongsToMany(Users, {
   through: ChallengeParticipants,
+  foreignKey: 'challengeId',
+});
+
+Users.belongsToMany(Challenge, {
+  through: Bookmark,
+  as: 'Bookmarks',
+  foreignKey: 'userId',
+});
+Challenge.belongsToMany(Users, {
+  through: Bookmark,
+  as: 'BookmarkedUsers',
   foreignKey: 'challengeId',
 });

--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -6,6 +6,7 @@ import './models/File';
 import './models/Point';
 import './models/Transactions';
 import './models/User';
+import './models/Bookmark';
 
 import './associations';
 

--- a/src/database/models/Bookmark.ts
+++ b/src/database/models/Bookmark.ts
@@ -1,0 +1,36 @@
+import {
+  Model,
+  DataTypes,
+  CreationOptional,
+  InferAttributes,
+  InferCreationAttributes,
+} from 'sequelize';
+import { sequelize } from '../sequelize';
+
+interface BookmarkModel
+  extends Model<
+    InferAttributes<BookmarkModel>,
+    InferCreationAttributes<BookmarkModel>
+  > {
+  id: CreationOptional<number>;
+  userId: number;
+  challengeId: number;
+}
+
+const Bookmark = sequelize.define<BookmarkModel>(
+  'Bookmark',
+  {
+    id: { type: DataTypes.INTEGER, autoIncrement: true, primaryKey: true },
+    userId: { type: DataTypes.INTEGER, allowNull: false },
+    challengeId: { type: DataTypes.INTEGER, allowNull: false },
+  },
+  {
+    paranoid: true,
+    charset: 'utf8',
+    collate: 'utf8_general_ci',
+    timestamps: true,
+    tableName: 'Bookmark',
+  }
+);
+
+export default Bookmark;


### PR DESCRIPTION
## Summary
- add Bookmark model for user-challenge associations
- register Bookmark model and add associations
- implement bookmark API with create, delete, and get handlers

## Testing
- `yarn lint` *(fails: package missing in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6840cb9d772c8324a44a0863e67f65bb