### PR TITLE
fix(#71) :: 이미지 마운트 되지 않는 문제 해결

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,8 @@ COPY . .
 
 COPY .env .env
 
+COPY public ./public
+
 RUN yarn build
 
 RUN yarn install --production --frozen-lockfile

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -121,7 +121,7 @@ pipeline {
                     docker run -d \
                     --name chaellimi \
                     -p 4001:3000 \
-                    -v $(pwd)/public/uploads:/root/public/uploads \
+                    -v /var/www/chaellimi/public/uploads:/root/public/uploads \
                     chaellimi
                 '''
                 sh 'sudo systemctl restart nginx'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Docker 이미지에 `public` 디렉토리가 포함되도록 변경되었습니다.
  * Jenkins 배포 시 업로드 파일의 호스트 경로가 `/var/www/chaellimi/public/uploads`로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->