### PR TITLE
fix(#96) :: 어드민 페이지 권한 주기

### DIFF
--- a/src/app/(admin)/layout.tsx
+++ b/src/app/(admin)/layout.tsx
@@ -4,6 +4,7 @@ import { useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { useSession } from 'next-auth/react';
 import Loading from '@/components/shared/Loading';
+import { useGetUserRole } from '@/service/shared/shared.query';
 
 export default function AuthLayout({
   children,
@@ -14,13 +15,18 @@ export default function AuthLayout({
   const { data: myInfo, status } = useSession();
   const isLoading = status === 'loading';
 
+  const { data: user, isLoading: isUserLoading } = useGetUserRole();
+
   useEffect(() => {
+    if (user?.data?.UserData?.role !== 'admin') {
+      router.replace('/');
+    }
     if (!isLoading && !myInfo) {
       router.replace('/login');
     }
-  }, [myInfo, router, isLoading]);
+  }, [myInfo, router, isLoading, user]);
 
-  if (isLoading) {
+  if (isLoading || isUserLoading) {
     return <Loading />;
   }
 

--- a/src/app/(private)/point/page.tsx
+++ b/src/app/(private)/point/page.tsx
@@ -8,6 +8,7 @@ import { PointDetailType } from '@/types/Point';
 import Loading from '@/components/shared/Loading';
 import { formatDateToDot } from '@/lib/utils/formatDateToDot';
 import { useSearchParams } from 'next/navigation';
+import useStatusBarBridge from '@/lib/hooks/useStatusBarBridge';
 
 const PointCategory = [
   { id: 1, name: '전체', type: '' },
@@ -31,6 +32,12 @@ const Point = () => {
   const backPath = useSearchParams().get('back');
 
   const [activeCategory, setActiveCategory] = useState<number>(1);
+
+  useStatusBarBridge({
+    backgroundColor: '#FFF',
+    translucent: true,
+    bottomBackgroundColor: '#FFF',
+  });
 
   const activeType =
     PointCategory.find((item) => item.id === activeCategory)?.type ?? '';

--- a/src/app/(private)/point/shop/page.tsx
+++ b/src/app/(private)/point/shop/page.tsx
@@ -3,6 +3,7 @@
 import { CustodyType, ProductType } from '@/app/api/shop/Product.type';
 import Header from '@/components/shared/Header';
 import Loading from '@/components/shared/Loading';
+import useStatusBarBridge from '@/lib/hooks/useStatusBarBridge';
 import { useGetPoint } from '@/service/Point/point.query';
 import { useGetCustody, useGetProduct } from '@/service/Shop/shop.query';
 import {
@@ -46,6 +47,12 @@ const Shop = () => {
 
   const { data, isLoading } = useGetProduct();
   const productData = data?.data;
+
+  useStatusBarBridge({
+    backgroundColor: '#FFF',
+    translucent: true,
+    bottomBackgroundColor: '#FFF',
+  });
 
   const { data: custodies, isLoading: isCustodyLoading } = useGetCustody();
   const activeCustodyData = custodies?.data?.activeCustody;

--- a/src/app/(private)/profile/bookmark/page.tsx
+++ b/src/app/(private)/profile/bookmark/page.tsx
@@ -6,6 +6,7 @@ import Header from '@/components/shared/Header';
 import Loading from '@/components/shared/Loading';
 import { usePostBookmarkUpdate } from '@/service/shared/shared.mutation';
 import { useGetBookmarkList } from '@/service/shared/shared.query';
+import useStatusBarBridge from '@/lib/hooks/useStatusBarBridge';
 
 interface BookmarkType {
   id: number;
@@ -41,6 +42,12 @@ const Bookmark = () => {
   const { mutate } = usePostBookmarkUpdate();
 
   const [checkedItems, setCheckedItems] = useState<Record<number, boolean>>({});
+
+  useStatusBarBridge({
+    backgroundColor: '#FFF',
+    translucent: true,
+    bottomBackgroundColor: '#FFF',
+  });
 
   useEffect(() => {
     if (bookmarkList.length > 0) {

--- a/src/app/(private)/profile/policies/page.tsx
+++ b/src/app/(private)/profile/policies/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import Header from '@/components/shared/Header';
+import useStatusBarBridge from '@/lib/hooks/useStatusBarBridge';
 import { useState } from 'react';
 
 // 간단한 아이콘 컴포넌트들
@@ -41,6 +42,12 @@ export default function PoliciesPage() {
     'service'
   );
   const [expandedSection, setExpandedSection] = useState<string | null>(null);
+
+  useStatusBarBridge({
+    backgroundColor: '#F7F7F7',
+    translucent: true,
+    bottomBackgroundColor: '#F7F7F7',
+  });
 
   const toggleSection = (section: string) => {
     setExpandedSection(expandedSection === section ? null : section);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 관리 페이지에 접속 시 사용자 역할 정보를 불러오는 동안 로딩 표시가 추가되었습니다.
  * 관리자가 아닌 사용자는 자동으로 홈 페이지로 이동됩니다.
  * 로그인하지 않은 사용자는 기존과 같이 로그인 페이지로 이동됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->