### PR TITLE
[Feat/#101]

### DIFF
--- a/src/app/(private)/point/page.tsx
+++ b/src/app/(private)/point/page.tsx
@@ -66,7 +66,7 @@ const Point = () => {
           <div className="text-b3">보유 포인트</div>
           <div className="flex items-center gap-4 text-Lg">
             <PointIcon />
-            {totalPoint?.data?.totalPoint.toLocaleString()}P
+            {Number(totalPoint?.data?.totalPoint).toLocaleString()}P
           </div>
         </div>
       </div>
@@ -93,7 +93,7 @@ const Point = () => {
         </div>
 
         {/* 리스트 */}
-        <div className="flex flex-col w-full h-full overflow-scroll scrollbar-hide custom601:h-[70%]">
+        <div className="flex flex-col w-full h-full overflow-scroll scrollbar-hide custom601:h-[70%] pb-28">
           {pointDetail?.data?.map((item: PointResponseType) => (
             <div
               className="flex items-center justify-between w-full py-5 border-b border-gray-100"

--- a/src/app/(private)/point/shop/page.tsx
+++ b/src/app/(private)/point/shop/page.tsx
@@ -97,7 +97,8 @@ const Shop = () => {
         <div className="flex flex-col w-full gap-4 px-6 mt-4 overflow-y-scroll scrollbar-hide">
           <div className="flex items-center justify-start w-full h-12 gap-[0.62rem] bg-yellow-100 px-5 py-3 rounded-xl text-b3">
             <PointIcon />
-            현재 보유 포인트 {pointData?.data?.totalPoint}P
+            현재 보유 포인트{' '}
+            {Number(pointData?.data?.totalPoint).toLocaleString()}P
           </div>
 
           <div className="grid grid-cols-4 gap-x-5 gap-y-5">
@@ -133,7 +134,9 @@ const Shop = () => {
 
                     <div>
                       <div className="text-c1">{item.brand}</div>
-                      <div className="text-h3">{item.price}P</div>
+                      <div className="text-h3">
+                        {Number(item.price).toLocaleString()}P
+                      </div>
                       <div className="text-b3">{item.title}</div>
                     </div>
                   </div>
@@ -188,7 +191,9 @@ const Shop = () => {
                           </div>
                           <div>
                             <div className="text-c1">{item.product.brand}</div>
-                            <div className="text-h3">{item.product.price}P</div>
+                            <div className="text-h3">
+                              {Number(item.product.price).toLocaleString()}P
+                            </div>
                             <div className="text-b3">{item.product.title}</div>
                           </div>
                         </div>
@@ -227,7 +232,9 @@ const Shop = () => {
 
                         <div>
                           <div className="text-c1">{item.product.brand}</div>
-                          <div className="text-h3">{item.product.price}P</div>
+                          <div className="text-h3">
+                            {Number(item.product.price).toLocaleString()}P
+                          </div>
                           <div className="text-b3">{item.product.title}</div>
                         </div>
                       </div>


### PR DESCRIPTION
## ✅ 작업 내용 요약
- 상점 페이지 3자리 콤마 처리 (.toLocaleString())
- 포인트 내역 스크롤 밑 부분 안보이는 문제 해결

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **스타일**
  * 포인트 상세 내역 리스트 컨테이너에 하단 패딩이 추가되어 스크롤 시 레이아웃이 개선되었습니다.

* **버그 수정**
  * 포인트 및 상품 가격 표시가 숫자 단위 구분(쉼표 등)으로 보다 보기 쉽게 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->